### PR TITLE
fix: improve Erlang SDK path normalization for Windows

### DIFF
--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/common/ErlangSdkFinder.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/common/ErlangSdkFinder.kt
@@ -69,7 +69,8 @@ object ErlangSdkFinder {
         val pathDirs = System.getenv("PATH").split(File.pathSeparator)
 
         for (dir in pathDirs) {
-            var path = Path(dir)
+            val cleaned = FsUtils.sanitizeUserPath(dir)
+            var path = Path(cleaned)
             try {
                 path = path.toAbsolutePath()
             } catch (_: Exception) {

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/common/ErlangSdkFinder.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/common/ErlangSdkFinder.kt
@@ -113,7 +113,7 @@ fun validateErlangSdkShape(path: Path): Boolean {
             erlExecutable.exists() && erlExecutable.isExecutable()
 }
 
-fun captureErlang(path: Path): ErlangSdk? {
+fun captureErlang(path: Path): ErlangSdk {
     if (!path.exists() || !path.isDirectory()) {
         return ErlangSdk(path.toString(), false)
     }

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/common/FsUtils.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/common/FsUtils.kt
@@ -8,6 +8,20 @@ import java.nio.file.Path
 import kotlin.io.path.*
 
 object FsUtils {
+    private val INVISIBLE_CONTROL_CHARS = "\u200E\u200F\u202A\u202B\u202C\u202D\u202E".toCharArray().toSet()
+
+    fun sanitizeUserPath(input: String): String {
+        var s = input.trim()
+        // Remove invisible Unicode directionality/control marks that can sneak from clipboard
+        s = s.filter { ch -> !INVISIBLE_CONTROL_CHARS.contains(ch) }
+        // On Windows, normalize forward slashes to backslashes
+        if (SystemInfo.isWindows) {
+            s = s.replace('/', '\\')
+            // Collapse duplicate backslashes (but keep UNC prefix if present)
+            s = s.replace(Regex("""\\\\+"""), "\\") // Replace multiple backslashes with one
+        }
+        return s
+    }
     fun validateGleamPath(path: String): Boolean {
         val path = Path(path)
         if (!(path.exists() && path.isRegularFile() && path.isExecutable())) {

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/common/GleamProjectUtils.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/common/GleamProjectUtils.kt
@@ -1,11 +1,11 @@
 package com.github.themartdev.intellijgleam.ide.common
 
 import com.intellij.openapi.project.Project
-import kotlin.io.path.Path
 
 object GleamProjectUtils {
     fun getSrcDir(project: Project): String? {
         val projectPath = project.basePath ?: return null
-        return Path(projectPath).resolve("src").toString()
+        val sep = java.io.File.separator
+        return if (projectPath.endsWith(sep)) projectPath + "src" else projectPath + sep + "src"
     }
 }

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/runconf/run/GleamRunConfigurationProducer.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/runconf/run/GleamRunConfigurationProducer.kt
@@ -59,7 +59,7 @@ class GleamRunConfigurationProducer : LazyRunConfigurationProducer<GleamRunConfi
 
     private fun getModulePath(element: PsiElement): String {
         val virtualFile = element.containingFile.virtualFile ?: return ""
-        return virtualFile.path
+        //return virtualFile.path
         val projectBasePath = element.project.basePath ?: return ""
         return virtualFile.path.removePrefix(projectBasePath).trimStart('/')
     }

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/runconf/run/GleamRunConfigurationState.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/runconf/run/GleamRunConfigurationState.kt
@@ -43,9 +43,9 @@ class GleamRunConfigurationState(
 
     private fun adjustPathWithErlang(path: String): String {
         val pathDirs = path.split(File.pathSeparator).toMutableList()
-        val erlangSdkPath = configuration.getActualErlangPath()
-        val erlangBin = File(erlangSdkPath).resolve("bin").absolutePath
-        if (erlangSdkPath.isNotEmpty()) {
+        val erlangSdkRoot = configuration.getNormalizedErlangSdkRoot()
+        if (erlangSdkRoot.isNotEmpty()) {
+            val erlangBin = File(erlangSdkRoot).resolve("bin").absolutePath
             pathDirs.add(0, erlangBin)
         }
         return pathDirs.joinToString(File.pathSeparator)

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/ui/components/AbstractPathComboBox.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/ui/components/AbstractPathComboBox.kt
@@ -1,5 +1,6 @@
 package com.github.themartdev.intellijgleam.ide.ui.components
 
+import com.github.themartdev.intellijgleam.ide.common.FsUtils
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.project.Project
@@ -58,8 +59,9 @@ abstract class AbstractExecutablePathComboBox(protected val project: Project?) :
                 selectedItem = null
                 return
             }
-            addItem(value)
-            selectedItem = value
+            val sanitized = FsUtils.sanitizeUserPath(value)
+            addItem(sanitized)
+            selectedItem = sanitized
         }
 
     abstract fun showBrowseDialog()

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/ui/components/ErlangPathComboBox.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/ui/components/ErlangPathComboBox.kt
@@ -5,7 +5,6 @@ import com.github.themartdev.intellijgleam.ide.common.captureErlang
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.project.Project
-import kotlin.io.path.Path
 
 class ErlangPathComboBox(project: Project) : AbstractExecutablePathComboBox(project) {
     override fun computeVersionInline(path: String): String? {

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/ui/components/ErlangPathComboBox.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/ui/components/ErlangPathComboBox.kt
@@ -1,5 +1,6 @@
 package com.github.themartdev.intellijgleam.ide.ui.components
 
+import com.github.themartdev.intellijgleam.ide.common.FsUtils
 import com.github.themartdev.intellijgleam.ide.common.captureErlang
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
@@ -8,7 +9,7 @@ import kotlin.io.path.Path
 
 class ErlangPathComboBox(project: Project) : AbstractExecutablePathComboBox(project) {
     override fun computeVersionInline(path: String): String? {
-        val executable = captureErlang(Path(path))
+        val executable = captureErlang(kotlin.io.path.Path(FsUtils.sanitizeUserPath(path)))
         return executable?.version
     }
 
@@ -18,7 +19,7 @@ class ErlangPathComboBox(project: Project) : AbstractExecutablePathComboBox(proj
         val selectedFiles = FileChooser.chooseFiles(fileChooserDescriptor, project, null)
         if (selectedFiles.isNotEmpty()) {
             val path = selectedFiles[0].path
-            selectedPath = path
+            selectedPath = FsUtils.sanitizeUserPath(path)
         }
     }
 }


### PR DESCRIPTION
### Summary
- Fix `gleam run -m` to always receive a valid module qualifier (e.g., `first_gleam` or `sub/test_sub`) instead of an absolute path or a truncated basename.
- Accept Erlang path in multiple common forms (SDK root, `bin` directory, or `erl(.exe)`) and normalize it to the SDK root for validation and runtime PATH setup.
- Introduce safe path sanitization to remove hidden Unicode control characters and normalize separators, preventing malformed paths and Windows-specific issues.
- Clearer validation errors and a reliable PATH ensure `erl` is found when running from the IDE.

### Why
- On Windows, naive string operations and mixed separators were causing `-m` to receive absolute file paths (`C:/.../src/first_gleam`) which are invalid for Gleam, or to collapse nested modules to just the basename (`test_sub` instead of `sub/test_sub`).
- Users commonly set Erlang to `...\bin\erl.exe` or the `...\bin` folder. Previously this was rejected; the plugin expected only the SDK root directory. At runtime, PATH augmentation also misbehaved if the input wasn’t the SDK root.
- Some environments introduced invisible Unicode characters (e.g., U+200E) into pasted paths, which caused absolute Windows paths to be misinterpreted and concatenated onto other directories, leading to malformed paths like `<base>\C:\Program Files\Erlang OTP\bin\erl.exe`.

### What changed
#### 1) Module qualifier generation (fix `-m` for both root and nested modules)
- File: `src\main\kotlin\com\github\themartdev\intellijgleam\ide\runconf\run\GleamRunConfiguration.kt`
  - Rewrote `getModuleQualifier()` to:
    - Accept plain module names as-is (strip trailing `.gleam` if present).
    - Normalize separators and correctly handle project-relative inputs that begin with `src` (e.g., `src/sub/test_sub.gleam` -> `sub/test_sub`).
    - For absolute file paths, robustly strip the project `src` directory prefix with system-aware and case-aware comparison (Windows-insensitive).
    - Preserve subdirectory structure and strip `.gleam`. Emit forward slashes for Gleam (`foo/bar`).
    - Fallback no longer collapses to basename; it keeps the relative path to avoid silently breaking nested modules.

- File: `src\main\kotlin\com\github\themartdev\intellijgleam\ide\runconf\run\GleamRunConfigurationProducer.kt`
  - `getModulePath()` continues to store a project-relative path by trimming the project base path, which now works seamlessly with the improved qualifier logic.

Result:
- `src/first_gleam.gleam` -> `-m first_gleam`
- `src/sub/test_sub.gleam` -> `-m sub/test_sub`

#### 2) Erlang path normalization and validation
- File: `src\main\kotlin\com\github\themartdev\intellijgleam\ide\runconf\run\GleamRunConfiguration.kt`
  - Added `getNormalizedErlangSdkRoot()` using `java.io.File`:
    - If the user picks `erl(.exe)`, go up to `bin`, then to the SDK root.
    - If the user picks `bin`, go up one to the SDK root.
    - If the directory already contains `bin`, treat it as SDK root.
    - Else return as-is (fallback).
  - `checkConfiguration()`:
    - Validates the normalized SDK root via `File` checks: existence, directories `bin`, `lib`, `releases`, and an executable `erl(.exe)`.
    - Uses clearer error messages that reference the SDK directory shape.

- File: `src\main\kotlin\com\github\themartdev\intellijgleam\ide\runconf\run\GleamRunConfigurationState.kt`
  - PATH augmentation now prefixes `<normalized-SDK-root>\bin` to ensure `erl` is discoverable by the launched `gleam` process.

Result:
- Users can configure Erlang as SDK root, `bin`, or `erl(.exe)`. The plugin normalizes this to the SDK root and validates consistently.

#### 3) Path sanitization to prevent malformed paths and Windows issues
- File: `src\main\kotlin\com\github\themartdev\intellijgleam\ide\common\FsUtils.kt`
  - Added `sanitizeUserPath(String)`:
    - Strips invisible directionality/control characters (e.g., U+200E, U+200F, U+202A–U+202E).
    - On Windows, converts `/` to `\` and collapses duplicate backslashes.
  - Applied this sanitization at key inputs:
    - `GleamRunConfiguration.getActualErlangPath()`
    - `ErlangSdkFinder.findErlangInPath()` when iterating PATH
    - `ErlangPathComboBox.computeVersionInline()` and selection handling
    - `AbstractExecutablePathComboBox.selectedPath` setter

- File: `src\main\kotlin\com\github\themartdev\intellijgleam\ide\common\GleamProjectUtils.kt`
  - Rewrote `getSrcDir()` using `java.io.File.separator` to avoid `Path` on Windows and edge cases with `:` and slashes.

Result:
- Absolute Windows paths remain absolute and are not erroneously concatenated with other directories.
- Copy/paste artifacts no longer break path handling.

### Affected files
- Run configuration and state:
  - `ide\runconf\run\GleamRunConfiguration.kt`
  - `ide\runconf\run\GleamRunConfigurationState.kt`
  - `ide\runconf\run\GleamRunConfigurationProducer.kt`
- Utilities and detection:
  - `ide\common\FsUtils.kt`
  - `ide\common\ErlangSdkFinder.kt`
  - `ide\common\GleamProjectUtils.kt`
- Settings UI:
  - `ide\ui\components\AbstractPathComboBox.kt`
  - `ide\ui\components\ErlangPathComboBox.kt`

### Compatibility and migration
- No storage schema changes; existing configurations continue to work.
- Module qualifier logic now supports both absolute and project-relative paths (and direct module names).
- Erlang path can be SDK root, `bin`, or `erl(.exe)`; we normalize and validate the SDK root automatically.
- OS-agnostic behavior is improved; hidden Unicode chars in pasted paths are handled safely.

### Edge cases considered
- Nested modules: `src/foo/bar/baz.gleam` -> `-m foo/bar/baz` (fixed).
- Files outside `src`: we no longer collapse to basename; we keep the relative portion provided. Future enhancement could validate against configured source roots and show a warning.
- Windows vs. UNIX separators: normalized and emitted as forward slashes for Gleam.
- Scoop shims or PATH shims: normalization attempts to resolve to the SDK root; if the SDK shape isn’t present, validation clearly explains what’s required.
- Hidden Unicode marks in paths: sanitized early to prevent malformed path joins.

### Testing done
- Build completed successfully.
- Manual checks:
  - `src/first_gleam.gleam` -> `-m first_gleam`.
  - `src/sub/test_sub.gleam` -> `-m sub/test_sub`.

### How to validate locally
- Settings > Gleam:
  - Set Gleam path to a valid `gleam(.exe)` or auto-detected one.
  - Set Erlang path to one of the accepted forms above.
- Create a run configuration from a `pub fn main` under `src` (including nested directories) and run.
  - Expect: `...\gleam.exe run -m <module>` where `<module>` includes subdirectories (e.g., `sub/test_sub`).
  - No "Program not found: erl" errors if the SDK is valid.
 

> I hope the description was clear and reflecting correctly the changes made, Im' happy to answer any question related to this PR.

Fixes #106.