### PR TITLE
New Project templating

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,3 @@
+This software includes code from IntelliJ IDEA Community Edition
+Copyright (C) JetBrains s.r.o.
+https://www.jetbrains.com/idea/

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ platformVersion = 2025.1
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins=com.redhat.devtools.lsp4ij:0.12.0
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins =
+platformBundledPlugins = com.intellij.java
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.9

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamDirectoryProjectGenerator.kt
@@ -1,0 +1,52 @@
+package com.github.themartdev.intellijgleam.ide.wizard
+
+import com.github.themartdev.intellijgleam.GleamBundle
+import com.github.themartdev.intellijgleam.GleamIcons
+import com.intellij.ide.fileTemplates.FileTemplateManager
+import com.intellij.ide.fileTemplates.FileTemplateUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupManager
+import com.intellij.openapi.util.NlsContexts
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.DirectoryProjectGeneratorBase
+import com.intellij.psi.PsiManager
+import java.util.*
+import javax.swing.Icon
+
+class GleamDirectoryProjectGenerator : DirectoryProjectGeneratorBase<Object>() {
+    override fun getName(): @NlsContexts.Label String = GleamBundle.message("gleam.wizard.directory.project.generator.name")
+
+    override fun getLogo(): Icon = GleamIcons.GLEAM
+
+    override fun generateProject(
+        project: Project,
+        baseDir: VirtualFile,
+        settings: Object,
+        module: Module
+    ) {
+        StartupManager.getInstance(project).runWhenProjectIsInitialized {
+            ApplicationManager.getApplication().invokeLater {
+                runWriteAction {
+                    val psiBaseDir = PsiManager.getInstance(project).findDirectory(baseDir) ?: return@runWriteAction
+                    val templateManager = FileTemplateManager.getInstance(project)
+
+                    val properties = Properties()
+                    GleamProjectAssets.assetProps(project.name, "")
+                        .forEach { (key, value) -> properties[key] = value }
+
+                    GleamProjectAssets.fileAssets().forEach { (sourcePath, templateName) ->
+                        val pathParts = sourcePath.split("/").toMutableList()
+                        val targetFile = pathParts.removeLast()
+                        var dir = psiBaseDir
+                        pathParts.forEach { dir = dir.createSubdirectory(it) }
+                        val template = templateManager.getInternalTemplate(templateName)
+                        FileTemplateUtil.createFromTemplate(template, targetFile, properties, dir)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamNewProjectWizard.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamNewProjectWizard.kt
@@ -1,0 +1,29 @@
+package com.github.themartdev.intellijgleam.ide.wizard
+
+import com.github.themartdev.intellijgleam.GleamIcons
+import com.intellij.ide.util.projectWizard.WizardContext
+import com.intellij.ide.wizard.GeneratorNewProjectWizard
+import com.intellij.ide.wizard.NewProjectWizardBaseStep
+import com.intellij.ide.wizard.NewProjectWizardChainStep.Companion.nextStep
+import com.intellij.ide.wizard.NewProjectWizardStep
+import com.intellij.ide.wizard.RootNewProjectWizardStep
+import com.intellij.ide.wizard.language.LanguageGeneratorNewProjectWizard
+import org.jetbrains.annotations.NonNls
+
+class GleamNewProjectWizard(override val id: @NonNls String) : GeneratorNewProjectWizard {
+
+    override val name = "Gleam"
+    override val icon = GleamIcons.GLEAM
+
+    override fun createStep(context: WizardContext): NewProjectWizardStep {
+        return RootNewProjectWizardStep(context)
+            .nextStep(::NewGleamProjectStep)
+            .nextStep(::NewProjectWizardBaseStep)
+            .nextStep(::NewGleamProjectAssetsStep)
+    }
+
+    // override fun createStep(parent: NewProjectWizardStep): NewProjectWizardStep {
+    //     return NewGleamProjectStep(parent).nextStep(::NewGleamProjectAssetsStep)
+    // }
+
+}

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamNewProjectWizard.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamNewProjectWizard.kt
@@ -21,8 +21,4 @@ class GleamNewProjectWizard : GeneratorNewProjectWizard {
             .nextStep(::NewGleamProjectAssetsStep)
     }
 
-    // override fun createStep(parent: NewProjectWizardStep): NewProjectWizardStep {
-    //     return NewGleamProjectStep(parent).nextStep(::NewGleamProjectAssetsStep)
-    // }
-
 }

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamNewProjectWizard.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamNewProjectWizard.kt
@@ -3,22 +3,21 @@ package com.github.themartdev.intellijgleam.ide.wizard
 import com.github.themartdev.intellijgleam.GleamIcons
 import com.intellij.ide.util.projectWizard.WizardContext
 import com.intellij.ide.wizard.GeneratorNewProjectWizard
-import com.intellij.ide.wizard.NewProjectWizardBaseStep
+import com.intellij.ide.wizard.GitNewProjectWizardStep
 import com.intellij.ide.wizard.NewProjectWizardChainStep.Companion.nextStep
 import com.intellij.ide.wizard.NewProjectWizardStep
 import com.intellij.ide.wizard.RootNewProjectWizardStep
-import com.intellij.ide.wizard.language.LanguageGeneratorNewProjectWizard
-import org.jetbrains.annotations.NonNls
 
-class GleamNewProjectWizard(override val id: @NonNls String) : GeneratorNewProjectWizard {
+class GleamNewProjectWizard : GeneratorNewProjectWizard {
 
+    override val id: String = "GleamArchetype"
     override val name = "Gleam"
     override val icon = GleamIcons.GLEAM
 
     override fun createStep(context: WizardContext): NewProjectWizardStep {
         return RootNewProjectWizardStep(context)
             .nextStep(::NewGleamProjectStep)
-            .nextStep(::NewProjectWizardBaseStep)
+            .nextStep(::NewGleamProjectGitStep)
             .nextStep(::NewGleamProjectAssetsStep)
     }
 

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamNewProjectWizard.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamNewProjectWizard.kt
@@ -18,6 +18,7 @@ class GleamNewProjectWizard : GeneratorNewProjectWizard {
         return RootNewProjectWizardStep(context)
             .nextStep(::NewGleamProjectStep)
             .nextStep(::NewGleamProjectGitStep)
+            .nextStep(::NewGleamProjectTargetStep)
             .nextStep(::NewGleamProjectAssetsStep)
     }
 

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamProjectAssets.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/GleamProjectAssets.kt
@@ -1,0 +1,18 @@
+package com.github.themartdev.intellijgleam.ide.wizard
+
+class GleamProjectAssets {
+    companion object {
+        fun assetDirs(): List<String> = listOf("src")
+        fun fileAssets(): List<Pair<String, String>> = listOf(
+            Pair("gleam.toml", "gleam.toml"),
+            Pair(".gitignore", "gleam.gitignore"),
+            Pair("src/main.gleam", "main.gleam")
+        )
+
+        fun assetProps(name: String, target: String): Array<Pair<String, String>> =
+            arrayOf(
+                Pair("gleamProjectName", name),
+                Pair("gleamProjectTarget", target),
+            )
+    }
+}

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectAssetsStep.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectAssetsStep.kt
@@ -1,0 +1,30 @@
+package com.github.themartdev.intellijgleam.ide.wizard
+
+import com.intellij.ide.projectWizard.generators.AssetsNewProjectWizardStep;
+import com.intellij.ide.starters.local.GeneratorResourceFile
+import com.intellij.ide.wizard.NewProjectWizardBaseStep
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+
+class NewGleamProjectAssetsStep(private val parent: NewProjectWizardBaseStep) : AssetsNewProjectWizardStep(parent) {
+    override fun setupAssets(project: Project) {
+        if (project.name.startsWith("gleam_")) {
+            error("We were not able to create your project as `${project.name}` has the reserved " +
+                    "prefix `gleam_`. This prefix is intended for official Gleam packages only.")
+        }
+        if (!project.name.matches(Regex("[a-z][a-z0-9_]*"))) {
+            error("Invalid project name: `${project.name}`. Project names must start with a lowercase letter and may " +
+                    "only contain lowercase letters, numbers and underscores.")
+        }
+
+        setOutputDirectory(project.guessProjectDir()?.path!!)
+        val props = arrayOf(Pair("gleamProjectName", project.name))
+
+        if (context.isCreatingNewProject) {
+            addTemplateAsset("gleam.toml", "gleam.toml", *props)
+
+            addEmptyDirectoryAsset("src")
+            addTemplateAsset("src/main.gleam", "main.gleam", *props)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectAssetsStep.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectAssetsStep.kt
@@ -1,22 +1,12 @@
 package com.github.themartdev.intellijgleam.ide.wizard
 
-import com.intellij.ide.projectWizard.generators.AssetsNewProjectWizardStep;
-import com.intellij.ide.starters.local.GeneratorResourceFile
-import com.intellij.ide.wizard.NewProjectWizardBaseStep
+import com.intellij.ide.projectWizard.generators.AssetsNewProjectWizardStep
+import com.intellij.ide.wizard.NewProjectWizardStep
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 
-class NewGleamProjectAssetsStep(private val parent: NewProjectWizardBaseStep) : AssetsNewProjectWizardStep(parent) {
+class NewGleamProjectAssetsStep(private val parent: NewProjectWizardStep) : AssetsNewProjectWizardStep(parent) {
     override fun setupAssets(project: Project) {
-        if (project.name.startsWith("gleam_")) {
-            error("We were not able to create your project as `${project.name}` has the reserved " +
-                    "prefix `gleam_`. This prefix is intended for official Gleam packages only.")
-        }
-        if (!project.name.matches(Regex("[a-z][a-z0-9_]*"))) {
-            error("Invalid project name: `${project.name}`. Project names must start with a lowercase letter and may " +
-                    "only contain lowercase letters, numbers and underscores.")
-        }
-
         setOutputDirectory(project.guessProjectDir()?.path!!)
         val props = arrayOf(Pair("gleamProjectName", project.name))
 

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectAssetsStep.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectAssetsStep.kt
@@ -5,13 +5,17 @@ import com.intellij.ide.wizard.NewProjectWizardStep
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 
-class NewGleamProjectAssetsStep(private val parent: NewProjectWizardStep) : AssetsNewProjectWizardStep(parent) {
+class NewGleamProjectAssetsStep(private val parent: NewGleamProjectTargetStep) : AssetsNewProjectWizardStep(parent) {
     override fun setupAssets(project: Project) {
         setOutputDirectory(project.guessProjectDir()?.path!!)
-        val props = arrayOf(Pair("gleamProjectName", project.name))
+        val props = arrayOf(
+            Pair("gleamProjectName", project.name),
+            Pair("gleamProjectTarget", parent.target),
+        )
 
         if (context.isCreatingNewProject) {
             addTemplateAsset("gleam.toml", "gleam.toml", *props)
+            addTemplateAsset(".gitignore", "gleam.gitignore", *props)
 
             addEmptyDirectoryAsset("src")
             addTemplateAsset("src/main.gleam", "main.gleam", *props)

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectAssetsStep.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectAssetsStep.kt
@@ -1,24 +1,18 @@
 package com.github.themartdev.intellijgleam.ide.wizard
 
 import com.intellij.ide.projectWizard.generators.AssetsNewProjectWizardStep
-import com.intellij.ide.wizard.NewProjectWizardStep
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 
 class NewGleamProjectAssetsStep(private val parent: NewGleamProjectTargetStep) : AssetsNewProjectWizardStep(parent) {
+
     override fun setupAssets(project: Project) {
         setOutputDirectory(project.guessProjectDir()?.path!!)
-        val props = arrayOf(
-            Pair("gleamProjectName", project.name),
-            Pair("gleamProjectTarget", parent.target),
-        )
+        val props = GleamProjectAssets.assetProps(project.name, parent.target)
 
         if (context.isCreatingNewProject) {
-            addTemplateAsset("gleam.toml", "gleam.toml", *props)
-            addTemplateAsset(".gitignore", "gleam.gitignore", *props)
-
-            addEmptyDirectoryAsset("src")
-            addTemplateAsset("src/main.gleam", "main.gleam", *props)
+            GleamProjectAssets.assetDirs().forEach { dir -> addEmptyDirectoryAsset(dir) }
+            GleamProjectAssets.fileAssets().forEach { (sourcePath, templateName) -> addTemplateAsset(sourcePath, templateName, *props) }
         }
     }
 }

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectGitStep.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectGitStep.kt
@@ -23,7 +23,8 @@ import com.intellij.ui.dsl.builder.whenStateChangedFromUi
 import java.nio.file.Path
 
 /**
- * A re-implementation of GitNewProjectWizardStep, to fit with the NewProjectWizardBaseStep re-implementation
+ * A re-implementation of GitNewProjectWizardStep, to fit with the NewProjectWizardBaseStep re-implementation.
+ * Identical to the original, other than dropping the internal-only `whenProjectCreated()` call.
  *
  * @see com.intellij.ide.wizard.GitNewProjectWizardStep
  */
@@ -60,11 +61,9 @@ class NewGleamProjectGitStep(
             if (git) {
                 val rootDirectory = Path.of(path).resolve(name).refreshAndFindVirtualDirectory()
                 if (rootDirectory != null) {
-                    whenProjectCreated(project) {
-                        runBackgroundableTask(IdeBundle.message("progress.title.creating.git.repository"), project) {
-                            setupProjectSafe(project, UIBundle.message("error.project.wizard.new.project.git")) {
-                                gitRepositoryInitializer!!.initRepository(project, rootDirectory, true)
-                            }
+                    runBackgroundableTask(IdeBundle.message("progress.title.creating.git.repository"), project) {
+                        setupProjectSafe(project, UIBundle.message("error.project.wizard.new.project.git")) {
+                            gitRepositoryInitializer!!.initRepository(project, rootDirectory, true)
                         }
                     }
                 }

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectGitStep.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectGitStep.kt
@@ -1,0 +1,78 @@
+package com.github.themartdev.intellijgleam.ide.wizard
+
+import com.intellij.ide.IdeBundle
+import com.intellij.ide.projectWizard.NewProjectWizardCollector.Base.logGitChanged
+import com.intellij.ide.projectWizard.NewProjectWizardCollector.Base.logGitFinished
+import com.intellij.ide.wizard.AbstractNewProjectWizardStep
+import com.intellij.ide.wizard.GitNewProjectWizardData
+import com.intellij.ide.wizard.NewProjectWizardBaseData
+import com.intellij.ide.wizard.NewProjectWizardBaseStep
+import com.intellij.ide.wizard.NewProjectWizardStep.Companion.GIT_PROPERTY_NAME
+import com.intellij.ide.wizard.setupProjectSafe
+import com.intellij.ide.wizard.whenProjectCreated
+import com.intellij.openapi.GitRepositoryInitializer
+import com.intellij.openapi.observable.util.bindBooleanStorage
+import com.intellij.openapi.progress.runBackgroundableTask
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.refreshAndFindVirtualDirectory
+import com.intellij.ui.UIBundle
+import com.intellij.ui.dsl.builder.BottomGap
+import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.whenStateChangedFromUi
+import java.nio.file.Path
+
+/**
+ * A re-implementation of GitNewProjectWizardStep, to fit with the NewProjectWizardBaseStep re-implementation
+ *
+ * @see com.intellij.ide.wizard.GitNewProjectWizardStep
+ */
+class NewGleamProjectGitStep(
+    parent: NewGleamProjectStep
+) : AbstractNewProjectWizardStep(parent),
+    NewProjectWizardBaseData by parent,
+    GitNewProjectWizardData {
+
+    private val gitRepositoryInitializer = GitRepositoryInitializer.getInstance()
+
+    private val isGitStepEnabled = gitRepositoryInitializer != null && context.isCreatingNewProject
+
+    private val gitProperty = propertyGraph.property(false)
+        .bindBooleanStorage(GIT_PROPERTY_NAME)
+
+    override val git: Boolean get() = isGitStepEnabled && gitProperty.get()
+
+    override fun setupUI(builder: Panel) {
+        if (isGitStepEnabled) {
+            with(builder) {
+                row("") {
+                    checkBox(UIBundle.message("label.project.wizard.new.project.git.checkbox"))
+                        .bindSelected(gitProperty)
+                        .whenStateChangedFromUi { logGitChanged(it) }
+                        .onApply { logGitFinished(git) }
+                }.bottomGap(BottomGap.SMALL)
+            }
+        }
+    }
+
+    override fun setupProject(project: Project) {
+        setupProjectSafe(project, UIBundle.message("error.project.wizard.new.project.git")) {
+            if (git) {
+                val rootDirectory = Path.of(path).resolve(name).refreshAndFindVirtualDirectory()
+                if (rootDirectory != null) {
+                    whenProjectCreated(project) {
+                        runBackgroundableTask(IdeBundle.message("progress.title.creating.git.repository"), project) {
+                            setupProjectSafe(project, UIBundle.message("error.project.wizard.new.project.git")) {
+                                gitRepositoryInitializer!!.initRepository(project, rootDirectory, true)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    init {
+        data.putUserData(GitNewProjectWizardData.KEY, this)
+    }
+}

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectStep.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectStep.kt
@@ -1,0 +1,22 @@
+package com.github.themartdev.intellijgleam.ide.wizard
+
+import com.github.themartdev.intellijgleam.ide.lsp.GleamServiceSettings
+import com.intellij.ide.wizard.AbstractNewProjectWizardStep
+import com.intellij.ide.wizard.NewProjectWizardBaseStep
+import com.intellij.ide.wizard.NewProjectWizardStep
+import com.intellij.openapi.project.DefaultProjectFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.platform.backend.workspace.WorkspaceModel
+import com.intellij.platform.workspace.jps.entities.ContentRootEntity
+import com.intellij.platform.workspace.jps.entities.ModuleEntity
+import com.intellij.platform.workspace.jps.entities.SourceRootEntity
+import com.intellij.platform.workspace.jps.entities.SourceRootTypeId
+import com.intellij.platform.workspace.jps.entities.modifyModuleEntity
+import java.util.concurrent.TimeUnit
+
+public class NewGleamProjectStep(parentStep: NewProjectWizardStep) : AbstractNewProjectWizardStep(parentStep) {
+    override fun setupProject(project: Project) {
+        super.setupProject(project)
+    }
+}

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectStep.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectStep.kt
@@ -1,22 +1,215 @@
 package com.github.themartdev.intellijgleam.ide.wizard
 
-import com.github.themartdev.intellijgleam.ide.lsp.GleamServiceSettings
+import com.github.themartdev.intellijgleam.GleamBundle
+import com.intellij.ide.IdeBundle.message
+import com.intellij.ide.projectWizard.NewProjectWizardCollector.Base.logLocationChanged
+import com.intellij.ide.projectWizard.NewProjectWizardCollector.Base.logNameChanged
+import com.intellij.ide.util.installNameGenerators
+import com.intellij.ide.util.projectWizard.ModuleBuilder
+import com.intellij.ide.util.projectWizard.WizardContext
 import com.intellij.ide.wizard.AbstractNewProjectWizardStep
-import com.intellij.ide.wizard.NewProjectWizardBaseStep
+import com.intellij.ide.wizard.NewProjectWizardBaseData
 import com.intellij.ide.wizard.NewProjectWizardStep
-import com.intellij.openapi.project.DefaultProjectFactory
+import com.intellij.openapi.application.invokeAndWaitIfNeeded
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.observable.properties.GraphProperty
+import com.intellij.openapi.observable.properties.ObservableProperty
+import com.intellij.openapi.observable.util.*
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.guessProjectDir
-import com.intellij.platform.backend.workspace.WorkspaceModel
-import com.intellij.platform.workspace.jps.entities.ContentRootEntity
-import com.intellij.platform.workspace.jps.entities.ModuleEntity
-import com.intellij.platform.workspace.jps.entities.SourceRootEntity
-import com.intellij.platform.workspace.jps.entities.SourceRootTypeId
-import com.intellij.platform.workspace.jps.entities.modifyModuleEntity
-import java.util.concurrent.TimeUnit
+import com.intellij.openapi.project.rootManager
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.ui.BrowseFolderDescriptor.Companion.withPathToTextConvertor
+import com.intellij.openapi.ui.BrowseFolderDescriptor.Companion.withTextToPathConvertor
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.openapi.ui.getCanonicalPath
+import com.intellij.openapi.ui.getPresentablePath
+import com.intellij.openapi.ui.shortenTextWithEllipsis
+import com.intellij.openapi.ui.validation.*
+import com.intellij.openapi.ui.validation.CHECK_MODULE_PATH
+import com.intellij.openapi.ui.validation.CHECK_PROJECT_PATH
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.util.io.toCanonicalPath
+import com.intellij.openapi.util.io.toNioPathOrNull
+import com.intellij.openapi.vfs.toNioPathOrNull
+import com.intellij.ui.UIBundle
+import com.intellij.ui.dsl.builder.*
+import com.intellij.ui.util.getTextWidth
+import com.intellij.util.applyIf
+import java.nio.file.Path
+import kotlin.io.path.name
 
-public class NewGleamProjectStep(parentStep: NewProjectWizardStep) : AbstractNewProjectWizardStep(parentStep) {
+/**
+ * A re-implementation of NewProjectWizardBaseStep, with stricter module naming, to fit Gleam.
+ *
+ * @see NewProjectWizardBaseStep
+ */
+class NewGleamProjectStep(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent), NewProjectWizardBaseData {
+    override val nameProperty: GraphProperty<String> = propertyGraph.lazyProperty(::suggestName)
+    override val pathProperty: GraphProperty<String> = propertyGraph.lazyProperty { suggestLocation().toCanonicalPath() }
+
+    override var name: String by nameProperty
+    override var path: String by pathProperty
+
+    var defaultName: String = "untitled"
+
+    internal var bottomGap: Boolean = true
+
+    private fun suggestLocation(): Path {
+        val location = context.projectDirectory
+        if (context.isCreatingNewProject) {
+            return location
+        }
+        if (isModuleDirectory(location)) {
+            return location
+        }
+        val parentLocation = location.parent
+        if (parentLocation == null) {
+            return location
+        }
+        return parentLocation
+    }
+
+    private fun suggestName(): String {
+        val location = context.projectDirectory
+        if (path == location.parent?.toCanonicalPath()) {
+            return location.name
+        }
+        return suggestUniqueName()
+    }
+
+    private fun suggestUniqueName(): String {
+        val moduleNames = findAllModules().map { it.name }.toSet()
+        val path = path.toNioPathOrNull() ?: return defaultName
+        return FileUtil.createSequentFileName(path.toFile(), defaultName, "") {
+            !it.exists() && it.name !in moduleNames
+        }
+    }
+
+    private fun findAllModules(): List<Module> {
+        val project = context.project ?: return emptyList()
+        val moduleManager = ModuleManager.getInstance(project)
+        return moduleManager.modules.toList()
+    }
+
+    private fun isModuleDirectory(path: Path): Boolean {
+        return findAllModules().asSequence()
+            .flatMap { it.rootManager.contentRoots.asSequence() }
+            .any { it.isDirectory && it.toNioPathOrNull() == path }
+    }
+
+    init {
+        nameProperty.dependsOn(pathProperty, ::suggestUniqueName)
+    }
+
+    val CHECK_GLEAM_NAME: DialogValidation.WithTwoParameters<Project?, () -> String> = validationErrorFor { project, name ->
+        if (name.startsWith("gleam_")) {
+            return@validationErrorFor GleamBundle.message("gleam.wizard.newproject.reserved.error")
+        }
+        if (!name.matches(Regex("[a-z][a-z0-9_]*"))) {
+            return@validationErrorFor GleamBundle.message("gleam.wizard.newproject.illegal.error")
+        }
+        return@validationErrorFor null
+    }
+
+    val CHECK_MODULE_NAME: DialogValidation.WithTwoParameters<Project?, () -> String> = CHECK_GLEAM_NAME and CHECK_NAME_FORMAT and CHECK_FREE_MODULE_NAME and CHECK_NO_RESERVED_WORDS
+
+    override fun setupUI(builder: Panel) {
+        val locationProperty = pathProperty.joinCanonicalPath(nameProperty)
+        with(builder) {
+            row(UIBundle.message("label.project.wizard.new.project.name")) {
+                textField()
+                    .bindText(nameProperty.trim())
+                    .columns(COLUMNS_MEDIUM)
+                    .validationRequestor(WHEN_GRAPH_PROPAGATION_FINISHED(propertyGraph))
+                    .trimmedTextValidation(CHECK_NON_EMPTY, CHECK_MODULE_NAME(context.project))
+                    .applyIf(context.isCreatingNewProject) { validation(CHECK_PROJECT_PATH(context.project, locationProperty)) }
+                    .applyIf(!context.isCreatingNewProject) { validation(CHECK_MODULE_PATH(context.project, locationProperty)) }
+                    .focused()
+                    .gap(RightGap.SMALL)
+                    .whenTextChangedFromUi { logNameChanged() }
+                installNameGenerators(getBuilderId(), nameProperty)
+            }.bottomGap(BottomGap.SMALL)
+
+            val locationRow = row(UIBundle.message("label.project.wizard.new.project.location")) {
+                val fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
+                    .withTitle(message("title.select.project.file.directory", context.presentationName))
+                    .withPathToTextConvertor(::getPresentablePath)
+                    .withTextToPathConvertor(::getCanonicalPath)
+                textFieldWithBrowseButton(fileChooserDescriptor, context.project)
+                    .bindText(pathProperty.toUiPathProperty())
+                    .align(AlignX.FILL)
+                    .trimmedTextValidation(CHECK_NON_EMPTY, CHECK_DIRECTORY)
+                    .whenTextChangedFromUi { logLocationChanged() }
+                    .locationComment(context, locationProperty)
+            }
+
+            if (bottomGap) {
+                locationRow.bottomGap(BottomGap.SMALL)
+            }
+
+            onApply {
+                context.projectName = name
+                context.setProjectFileDirectory(Path.of(path).resolve(name), false)
+            }
+        }
+    }
+
     override fun setupProject(project: Project) {
-        super.setupProject(project)
+        if (context.isCreatingNewProject) {
+            invokeAndWaitIfNeeded {
+                runWriteAction {
+                    val projectManager = ProjectRootManager.getInstance(project)
+                    projectManager.projectSdk = context.projectJdk
+                }
+            }
+        }
+    }
+
+    private fun getBuilderId(): String? {
+        val projectBuilder = context.projectBuilder
+        if (projectBuilder is ModuleBuilder) {
+            return projectBuilder.builderId
+        }
+        return null
+    }
+
+    init {
+        data.putUserData(NewProjectWizardBaseData.KEY, this)
+    }
+
+    companion object {
+
+        /**
+         * Defines ration between location text field width and location comment width.
+         * Cannot be 1.0 or more because:
+         *  1. Comment width is dependent on location text field width;
+         *  2. Minimum location text field width cannot be less comment width.
+         * So this ratio makes a gap between minimum widths of comment and location.
+         * It allows smoothly resizing components (location and comment) when NPW dialog is resized.
+         */
+        private const val LOCATION_COMMENT_RATIO = 0.9f
+
+        private fun Cell<TextFieldWithBrowseButton>.locationComment(context: WizardContext, locationProperty: ObservableProperty<String>) {
+            comment("", MAX_LINE_LENGTH_NO_WRAP)
+            val comment = comment!!
+            val widthProperty = component.widthProperty
+            val commentProperty = operation(locationProperty, widthProperty) { path, width ->
+                val isCreatingNewProjectInt = context.isCreatingNewProjectInt
+                val commentWithEmptyPath = UIBundle.message("label.project.wizard.new.project.path.description", isCreatingNewProjectInt, "")
+                val commentWidthWithEmptyPath = comment.getTextWidth(commentWithEmptyPath)
+                val maxPathWidth = (LOCATION_COMMENT_RATIO * width).toInt() - commentWidthWithEmptyPath
+                val presentablePath = getPresentablePath(path)
+                val shortPresentablePath = shortenTextWithEllipsis(
+                    text = presentablePath,
+                    maxTextWidth = maxPathWidth,
+                    getTextWidth = comment::getTextWidth,
+                )
+                UIBundle.message("label.project.wizard.new.project.path.description", isCreatingNewProjectInt, shortPresentablePath)
+            }
+            comment.bind(commentProperty)
+        }
     }
 }

--- a/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectTargetStep.kt
+++ b/src/main/kotlin/com/github/themartdev/intellijgleam/ide/wizard/NewGleamProjectTargetStep.kt
@@ -1,0 +1,46 @@
+package com.github.themartdev.intellijgleam.ide.wizard
+
+import com.github.themartdev.intellijgleam.GleamBundle
+import com.github.themartdev.intellijgleam.ide.lsp.GleamLspMode
+import com.intellij.ide.projectWizard.NewProjectWizardCollector.Base.logGitChanged
+import com.intellij.ide.projectWizard.NewProjectWizardCollector.Base.logGitFinished
+import com.intellij.ide.projectWizard.generators.AssetsNewProjectWizardStep
+import com.intellij.ide.wizard.AbstractNewProjectWizardStep
+import com.intellij.ide.wizard.NewProjectWizardStep
+import com.intellij.ide.wizard.NewProjectWizardStep.Companion.GIT_PROPERTY_NAME
+import com.intellij.openapi.observable.properties.GraphProperty
+import com.intellij.openapi.observable.util.bindBooleanStorage
+import com.intellij.ui.UIBundle
+import com.intellij.ui.dsl.builder.BottomGap
+import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.bind
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.selected
+import com.intellij.ui.dsl.builder.whenStateChangedFromUi
+
+class NewGleamProjectTargetStep(private val parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent) {
+    val targetProperty: GraphProperty<String> = propertyGraph.property("")
+    var target: String by targetProperty
+
+    override fun setupUI(builder: Panel) {
+        with(builder) {
+            group(GleamBundle.message("gleam.wizard.newproject.configurable.group.target")) {
+                buttonsGroup {
+                    row {
+                        radioButton(
+                            GleamBundle.message("gleam.wizard.newproject.configurable.target.erlang"), ""
+                        ).comment(GleamBundle.message("gleam.wizard.newproject.configurable.target.erlang.help"))
+                    }
+                    row {
+                        radioButton(
+                            GleamBundle.message("gleam.wizard.newproject.configurable.target.javascript"), "target = \"javascript\"\n"
+                        ).comment(GleamBundle.message("gleam.wizard.newproject.configurable.target.javascript.help"))
+                    }
+                }.apply {
+                    bind(::target)
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/com.github.themartdev.intellijgleam-withJava.xml
+++ b/src/main/resources/META-INF/com.github.themartdev.intellijgleam-withJava.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
     <vendor>themartdev</vendor>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.java</depends>
     <depends>com.redhat.devtools.lsp4ij</depends>
 
     <resource-bundle>messages.GleamBundle</resource-bundle>
@@ -98,6 +99,8 @@
                 implementation="com.github.themartdev.intellijgleam.ide.runconf.run.GleamRunConfigurationProducer"/>
 
         <postStartupActivity implementation="com.github.themartdev.intellijgleam.ide.lifecycle.GleamStartupActivity"/>
+
+        <newProjectWizard.languageGenerator implementation="com.github.themartdev.intellijgleam.ide.wizard.GleamNewProjectWizard" />
 
         <lang.psiStructureViewFactory
                 language="Gleam"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,8 +5,12 @@
     <vendor>themartdev</vendor>
 
     <depends>com.intellij.modules.platform</depends>
-    <depends>com.intellij.java</depends>
     <depends>com.redhat.devtools.lsp4ij</depends>
+
+    <!-- Required to use AssetsNewProjectWizardStep -->
+    <depends optional="true" config-file="com.github.themartdev.intellijgleam-withJava.xml">
+      com.intellij.java
+    </depends>
 
     <resource-bundle>messages.GleamBundle</resource-bundle>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -100,7 +100,7 @@
 
         <postStartupActivity implementation="com.github.themartdev.intellijgleam.ide.lifecycle.GleamStartupActivity"/>
 
-        <newProjectWizard.languageGenerator implementation="com.github.themartdev.intellijgleam.ide.wizard.GleamNewProjectWizard" />
+        <newProjectWizard.generator implementation="com.github.themartdev.intellijgleam.ide.wizard.GleamNewProjectWizard" />
 
         <lang.psiStructureViewFactory
                 language="Gleam"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -105,6 +105,7 @@
         <postStartupActivity implementation="com.github.themartdev.intellijgleam.ide.lifecycle.GleamStartupActivity"/>
 
         <newProjectWizard.generator implementation="com.github.themartdev.intellijgleam.ide.wizard.GleamNewProjectWizard" />
+        <directoryProjectGenerator implementation="com.github.themartdev.intellijgleam.ide.wizard.GleamDirectoryProjectGenerator" />
 
         <lang.psiStructureViewFactory
                 language="Gleam"

--- a/src/main/resources/fileTemplates/internal/gleam.gitignore.ft
+++ b/src/main/resources/fileTemplates/internal/gleam.gitignore.ft
@@ -1,0 +1,4 @@
+*.beam
+*.ez
+/build
+erl_crash_dump

--- a/src/main/resources/fileTemplates/internal/gleam.toml.ft
+++ b/src/main/resources/fileTemplates/internal/gleam.toml.ft
@@ -1,6 +1,6 @@
 name = "${gleamProjectName}"
 version = "1.0.0"
-
+${gleamProjectTarget}
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.
 #

--- a/src/main/resources/fileTemplates/internal/gleam.toml.ft
+++ b/src/main/resources/fileTemplates/internal/gleam.toml.ft
@@ -1,0 +1,18 @@
+name = "${gleamProjectName}"
+version = "1.0.0"
+
+# Fill out these fields if you intend to generate HTML documentation or publish
+# your project to the Hex package manager.
+#
+# description = ""
+# licences = ["Apache-2.0"]
+# repository = { type = "github", user = "", repo = "" }
+# links = [{ title = "Website", href = "" }]
+#
+# For a full reference of all the available options, you can have a look at
+# https://gleam.run/writing-gleam/gleam-toml/.
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+
+[dev-dependencies]

--- a/src/main/resources/fileTemplates/internal/main.gleam.ft
+++ b/src/main/resources/fileTemplates/internal/main.gleam.ft
@@ -1,0 +1,5 @@
+import gleam/io
+
+pub fn main() {
+  io.println("Hello, ${gleamProjectName}!")
+}

--- a/src/main/resources/messages/GleamBundle.properties
+++ b/src/main/resources/messages/GleamBundle.properties
@@ -12,6 +12,11 @@ gleam.settings.lsp.configurable.lsp.disabled.help=Select this option to turn off
 
 gleam.wizard.newproject.reserved.error=The `gleam_` prefix is reserved for official Gleam packages
 gleam.wizard.newproject.illegal.error=Project names must start with a lowercase letter and may only contain lowercase letters, numbers and underscores.
+gleam.wizard.newproject.configurable.group.target=Compilation Target
+gleam.wizard.newproject.configurable.target.erlang=Erlang
+gleam.wizard.newproject.configurable.target.erlang.help=The default target
+gleam.wizard.newproject.configurable.target.javascript=JavaScript
+gleam.wizard.newproject.configurable.target.javascript.help=For node and the web
 
 gleam.notification.error.key=Gleam error
 

--- a/src/main/resources/messages/GleamBundle.properties
+++ b/src/main/resources/messages/GleamBundle.properties
@@ -18,6 +18,8 @@ gleam.wizard.newproject.configurable.target.erlang.help=The default target
 gleam.wizard.newproject.configurable.target.javascript=JavaScript
 gleam.wizard.newproject.configurable.target.javascript.help=For node and the web
 
+gleam.wizard.directory.project.generator.name=Gleam Project
+
 gleam.notification.error.key=Gleam error
 
 live.template.case.description=Case expression

--- a/src/main/resources/messages/GleamBundle.properties
+++ b/src/main/resources/messages/GleamBundle.properties
@@ -10,6 +10,9 @@ gleam.settings.lsp.configurable.lsp.enabled.help=Select this option to use Gleam
 gleam.settings.lsp.configurable.lsp.disabled=Disable language server
 gleam.settings.lsp.configurable.lsp.disabled.help=Select this option to turn off the Gleam Language Server.
 
+gleam.wizard.newproject.reserved.error=The `gleam_` prefix is reserved for official Gleam packages
+gleam.wizard.newproject.illegal.error=Project names must start with a lowercase letter and may only contain lowercase letters, numbers and underscores.
+
 gleam.notification.error.key=Gleam error
 
 live.template.case.description=Case expression


### PR DESCRIPTION
Hello, hope you don't mind an unsolicited PR :sweat_smile:

I tried to approximate the effects of `gleam new` for initializing projects. I'm pretty fresh to intellij plugin development, but I think this _mostly_ avoids stepping on your toes.

I couldn't find a good way to inject custom module-name validation (gleam's rules are more strict than IntelliJ's builtin classes), so I copied `NewProjectWizardBaseStep` out, more or less wholesale, and that necessitated doing the same for `GitNewProjectWizardStep`, which depends on NPWBS directly.

JetBrains' repos also use apache 2.0, so there should be no license issue, but I imported the NOTICE.txt from their repo to acknowledge this copy. And, for your perusal, here's a diff of the changes between my files and theirs (ignoring whitespace): [diff-from-intellij-builtins.txt](https://github.com/user-attachments/files/22620173/diff-from-intellij-builtins.txt)